### PR TITLE
Fix for login.gov deprecation of id_token_hint

### DIFF
--- a/src/main/java/mil/nga/keycloak/social/LoginGovIdentityProviderConfig.java
+++ b/src/main/java/mil/nga/keycloak/social/LoginGovIdentityProviderConfig.java
@@ -6,6 +6,7 @@ import org.keycloak.models.IdentityProviderModel;
 public class LoginGovIdentityProviderConfig extends OIDCIdentityProviderConfig {
     public static final String LOA1 = "http://idmanagement.gov/ns/assurance/loa/1";
     public static final String LOA3 = "http://idmanagement.gov/ns/assurance/loa/3";
+    public static final String DeepLogoutField = "deepLogout";
 
     public LoginGovIdentityProviderConfig(IdentityProviderModel identityProviderModel) {
         super(identityProviderModel);
@@ -21,6 +22,15 @@ public class LoginGovIdentityProviderConfig extends OIDCIdentityProviderConfig {
 
     public void setAcrValues(String acrValues) {
         getConfig().put("acr_values", acrValues);
+    }
+
+    public Boolean getDeepLogoutValue() {
+        String configValue = getConfig().getOrDefault(DeepLogoutField, "false");
+        return Boolean.parseBoolean(configValue);
+    }
+
+    public void setDeepLogoutValue(String deepLogoutValue) {
+        getConfig().put(DeepLogoutField, deepLogoutValue);
     }
 
 }

--- a/src/main/java/mil/nga/keycloak/social/LoginGovIdentityProviderFactory.java
+++ b/src/main/java/mil/nga/keycloak/social/LoginGovIdentityProviderFactory.java
@@ -36,13 +36,13 @@ public class LoginGovIdentityProviderFactory
 
     @Override
     public Map<String, String> parseConfig(KeycloakSession session, InputStream inputStream) {
-        OIDCConfigurationRepresentation rep;
+        LoginGovOIDCConfigurationRepresentation rep;
         try {
-            rep = JsonSerialization.readValue(inputStream, OIDCConfigurationRepresentation.class);
+            rep = JsonSerialization.readValue(inputStream, LoginGovOIDCConfigurationRepresentation.class);
         } catch (IOException e) {
             throw new RuntimeException("failed to load openid connect metadata", e);
         }
-        OIDCIdentityProviderConfig config = new OIDCIdentityProviderConfig(new IdentityProviderModel());
+        LoginGovIdentityProviderConfig config = new LoginGovIdentityProviderConfig(new IdentityProviderModel());
         config.setIssuer(rep.getIssuer());
         config.setLogoutUrl(rep.getLogoutEndpoint());
         config.setAuthorizationUrl(rep.getAuthorizationEndpoint());
@@ -53,6 +53,9 @@ public class LoginGovIdentityProviderFactory
             config.setUseJwksUrl(true);
             config.setJwksUrl(rep.getJwksUri());
         }
+
+        config.setDeepLogoutValue(rep.getDeepLogout().toString());
+
         return config.getConfig();
     }
 

--- a/src/main/java/mil/nga/keycloak/social/LoginGovOIDCConfigurationRepresentation.java
+++ b/src/main/java/mil/nga/keycloak/social/LoginGovOIDCConfigurationRepresentation.java
@@ -1,0 +1,23 @@
+package mil.nga.keycloak.social;
+
+import org.keycloak.protocol.oidc.representations.OIDCConfigurationRepresentation;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author <a href="mailto:bill@burkecentral.com">Bill Burke</a>
+ * @version $Revision: 1 $
+ */
+public class LoginGovOIDCConfigurationRepresentation extends OIDCConfigurationRepresentation {
+
+    @JsonProperty("deepLogout")
+    private Boolean deepLogout;
+
+    public Boolean getDeepLogout() {
+        return deepLogout;
+    }
+
+    public void setDeepLogout(Boolean deepLogout) {
+        this.deepLogout = deepLogout;
+    }
+
+}

--- a/src/main/resources/theme-resources/messages/admin-messages_en.properties
+++ b/src/main/resources/theme-resources/messages/admin-messages_en.properties
@@ -2,3 +2,5 @@ login_gov.acr_values=Authentication Context Class (acr_value)
 login_gov.acr_values.loa1=LOA1 :  Self-Asserted - (NIST 800-63-3) Identity Assurance Level l (IAL)
 login_gov.acr_values.loa3=LOA3 :  Proofed  - (NIST 800-63-3) Identity Assurance Level 2 (IAL)
 login_gov.acr_values.tooltip=The Authentication Context Class Reference values used to specify the LOA (level of assurance) of an account, either LOA1 or LOA3. This and the scope determine which user attributes will be available in the user info response.
+login_gov.deep_logout=Logout from Login.gov in addition to KeyCloak
+login_gov.deep_logout.tooltip=Redirect user to login.gov logout endpoint for them to terminate their login.gov session when logging out.

--- a/src/main/resources/theme-resources/resources/partials/realm-identity-provider-login.gov-ext.html
+++ b/src/main/resources/theme-resources/resources/partials/realm-identity-provider-login.gov-ext.html
@@ -11,3 +11,10 @@
     <kc-tooltip>{{:: 'login_gov.acr_values.tooltip' | translate}}</kc-tooltip>
 </div>
 
+<div class="form-group">
+    <label class="col-md-2 control-label" for="deepLogout">{{:: 'login_gov.deep_logout' | translate}}</label>
+    <div class="col-md-6">
+        <input ng-model="identityProvider.config.deepLogout" id="deepLogout" onoffswitchvalue on-text="{{:: 'onText' | translate}}" off-text="{{:: 'offText' | translate}}" />
+    </div>
+    <kc-tooltip>{{:: 'login_gov.deep_logout.tooltip' | translate}}</kc-tooltip>
+</div>


### PR DESCRIPTION
These are changes to fix the issue with Login.gov removal / rejection of id_token_hint on logout. 
See: https://developers.login.gov/oidc/#logout

This includes a new UI element that will allow admins to determine if users are logged out of only KeyCloak or both KeyCloak and login.gov when logging out from an application. 


